### PR TITLE
Changing from pixel to matrix values

### DIFF
--- a/delteme.txt
+++ b/delteme.txt
@@ -1,0 +1,2 @@
+
+This is just a test of sync

--- a/simulation/AllGraph.py
+++ b/simulation/AllGraph.py
@@ -33,10 +33,8 @@ class Graph:
             node_list.append([])
             # Create nodes in each row
             for i in range(NODE_NUM_W):
-                row = j*NODE_SIZE
-                col = i*NODE_SIZE
-                # Last row, add node
-                node_list[-1].append(Node(col, row, NODE_SIZE, self.canvas))
+                node_list[-1].append(Node(j, i, NODE_SIZE, self.canvas))
+
 
         # total number of nodes in the matrix
         self.node_number = (NODE_NUM_W * NODE_NUM_H)
@@ -92,14 +90,10 @@ class Graph:
         # The nodes have the <x, y> to render to canvas though, so this probably makes sense. 
 
         # this is a node here    
-        node_req = self.matrix[n1][n2]
+        node_req = self.matrix[n1 - 1][n2]
 
-        left_node = self.matrix[n1 - 25][n2]
-        right_node = self.matrix[n1 + 25][n2]
 
-        node_list = [left_node.center_tuple, right_node.center_tuple]
-
-        return node_list
+        return node_req
 
 
     def draw_line():

--- a/simulation/AllGraph.py
+++ b/simulation/AllGraph.py
@@ -65,6 +65,31 @@ class Graph:
         """
         return n
 
+    def get_left_node(self):
+        """
+        Get the node to the left of the given node
+        """
+        pass
+
+    def get_right_node(self):
+        """
+        Get node to the right of the given node
+        """
+        pass
+
+    def get_above_node(self):
+        """
+        Get the node above the given node
+        """
+        pass
+
+    def get_below_node(self):
+        """
+        Get the node beneath the given node 
+        """
+        pass
+        
+
     def get_matrix_n(self):
         """
         At the moment when one pulls a node from the matrix the values are it's 
@@ -91,7 +116,6 @@ class Graph:
 
         # this is a node here    
         node_req = self.matrix[n1 - 1][n2]
-
 
         return node_req
 

--- a/simulation/Node.py
+++ b/simulation/Node.py
@@ -20,6 +20,7 @@ class Node:
 
         x2 = x1 + side_len
         y2 = y1 + side_len
+        
         # initialise the coordinates for the vertice
         self.x1 = x1
         self.y1 = y1

--- a/simulation/Node.py
+++ b/simulation/Node.py
@@ -7,7 +7,9 @@ class Node:
 
     """
 
-    def __init__(self, x1, y1,
+    def __init__(self, 
+                 x1, 
+                 y1,
                  side_len,
                  canvas,
                  weight=1,
@@ -18,20 +20,28 @@ class Node:
                  seeker_colour = "#93FF46"
                  ):
 
-        x2 = x1 + side_len
-        y2 = y1 + side_len
-        
+
         # initialise the coordinates for the vertice
-        self.x1 = x1
-        self.y1 = y1
+
+        # These are the matrix positions for Node
+        self.mx = x1
+        self.my = y1
+
+        # These are the pixel positions for Node
+        self.x1 = x1 * side_len 
+        self.y1 = y1 * side_len
+
+        x2 = self.x1 + side_len
+        y2 = self.y1 + side_len
+
         self.x2 = x2
         self.y2 = y2
 
         self.side_len = side_len
 
         # get the center point of a node object
-        self.mx = (x1 + x2) / 2
-        self.my = (y1 + y2) / 2
+        # self.mx = (x1 + x2) / 2
+        # self.my = (y1 + y2) / 2
 
         self.center_tuple = (self.mx, self.my)
 
@@ -100,8 +110,13 @@ class Node:
         self.colour = c
 
     def __str__(self):
-        info = "x1 = {}, y1 = {},\nx2 = {}, y2 = {}\n".format(
-            self.x1, self.y1, self.x2, self.y2)
+        info = "Matrix <x,y> = <{},{}>\nPixel x1 = {}, Pixel y1 = {},\nPixel x2 = {}, Pixel y2 = {}\n".format(
+            self.mx,
+            self.my, 
+            self.x1, 
+            self.y1, 
+            self.x2, 
+            self.y2)
         return info
 
     def pass_the_butter(self):

--- a/simulation/simple-algorithm-pseudocode.markdown
+++ b/simulation/simple-algorithm-pseudocode.markdown
@@ -1,7 +1,7 @@
 This is just thinking aloud for the simple algorithm - 
 
 This should be run on a list of nodes representing the edges of the searched nodes in the graph
-
+```
 y pos = y position of Node (current node being searched)
 x pos = x position of the Node
 R = Robot (which will be fixed at this point)
@@ -21,3 +21,5 @@ if x pos > Rx:
 	Node is to the right of the robot
 	therefore
 	1 edge to search in +ve direction from the Robot
+
+```

--- a/simulation/simple-algorithm-pseudocode.markdown
+++ b/simulation/simple-algorithm-pseudocode.markdown
@@ -1,0 +1,23 @@
+This is just thinking aloud for the simple algorithm - 
+
+This should be run on a list of nodes representing the edges of the searched nodes in the graph
+
+y pos = y position of Node (current node being searched)
+x pos = x position of the Node
+R = Robot (which will be fixed at this point)
+Rx = Robot x position
+Ry = Robot y 
+iter-n = The number of iterations so far (3rd iteration, 4th etc)
+
+
+if y pos == iter-n from Ry: 
+	Node is EITHER a top node or a bottom node (checking should probably be implemented)
+	Node has 3 edges to search next
+if x pos < Rx: 
+	Node is to the left of the Robot
+	Therefore 
+	1 edge to search next in -ve direction from Robot
+if x pos > Rx: 
+	Node is to the right of the robot
+	therefore
+	1 edge to search in +ve direction from the Robot

--- a/simulation/testing-animation.py
+++ b/simulation/testing-animation.py
@@ -127,7 +127,8 @@ def main_animate():
 
     # print(test_graph.get_all_neighbours(fixed_robot))
 
-    print("Testing passing tuple value - ")
+
+    # Pass in the tuple to test graph methods
     print(test_graph.receive_tuple_position(robot_tuple))
 
 


### PR DESCRIPTION
This commit adds methods to the Graph class that need to be completed. 

Node class has matrix positions stored within it that should make it easier to access them via matrix values rather than using pixel positions. 

Center points for the nodes aren't currently being used so `mx` and `my` are used to represent the Matrix x,y instead of the nodes center (middle) x,y.

Pseudocode for the simple algorithm is also added. 